### PR TITLE
Fixed two issues with the CMake project

### DIFF
--- a/delynoi/include/delynoi/models/polygon/Triangle.h
+++ b/delynoi/include/delynoi/models/polygon/Triangle.h
@@ -35,7 +35,6 @@ public:
      */
     Triangle(std::vector<int> points, std::vector<Point>& p);
 
-
     Triangle(std::vector<int> points, std::vector<Point>& p, UniqueList<Point>& circumcenters);
 
     Triangle(std::vector<int> points, std::vector<Point>& p, std::vector<Point>& circumcenters);

--- a/delynoi/include/delynoi/voronoi/lib/CMakeLists.txt
+++ b/delynoi/include/delynoi/voronoi/lib/CMakeLists.txt
@@ -5,7 +5,7 @@ SET(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -pg")
 add_library(triangle STATIC triangle.c)
 target_compile_definitions(triangle PRIVATE -DTRILIBRARY -DANSI_DECLARATORS)
 if(WIN32)
-    target_compile_definitions(triangle PRIVATE -DNO_TIMER)
+    target_compile_definitions(triangle PUBLIC -DNO_TIMER)
 endif()
 
 # 'make install' to the correct locations (provided by GNUInstallDirs).
@@ -13,7 +13,6 @@ install(TARGETS triangle EXPORT TriangleConfig
         ARCHIVE  DESTINATION ${CMAKE_INSTALL_LIBDIR}
         LIBRARY  DESTINATION ${CMAKE_INSTALL_LIBDIR}
         RUNTIME  DESTINATION ${CMAKE_INSTALL_BINDIR})  # This is for Windows
-install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
 # This makes the project importable from the install directory
 # Put config file in per-project dir (name MUST match), can also

--- a/delynoi/include/delynoi/voronoi/lib/triangle.c
+++ b/delynoi/include/delynoi/voronoi/lib/triangle.c
@@ -213,7 +213,7 @@
 /* If yours is not a Unix system, define the NO_TIMER compiler switch to     */
 /*   remove the Unix-specific timing code.                                   */
 
-/* #define NO_TIMER */
+#define NO_TIMER
 
 /* To insert lots of self-checks for internal errors, define the SELF_CHECK  */
 /*   symbol.  This will slow down the program significantly.  It is best to  */

--- a/delynoi/include/delynoi/voronoi/lib/triangle.c
+++ b/delynoi/include/delynoi/voronoi/lib/triangle.c
@@ -213,7 +213,7 @@
 /* If yours is not a Unix system, define the NO_TIMER compiler switch to     */
 /*   remove the Unix-specific timing code.                                   */
 
-#define NO_TIMER
+/* #define NO_TIMER */
 
 /* To insert lots of self-checks for internal errors, define the SELF_CHECK  */
 /*   symbol.  This will slow down the program significantly.  It is best to  */

--- a/delynoi/src/models/polygon/Polygon.cpp
+++ b/delynoi/src/models/polygon/Polygon.cpp
@@ -98,8 +98,7 @@ double Polygon::getDiameter(std::vector<Point>& points) {
 
 Point Polygon::getCentroid(std::vector<Point>& points) {
     if(!this->centroid.isValid()){
-        std::vector<Point> thisPoints = this->getPoints(points);
-        this->centroid = this->calculateCentroid(thisPoints);
+        this->centroid = this->calculateCentroid(points);
     }
 
     return this->centroid;

--- a/delynoi/src/models/polygon/Polygon.cpp
+++ b/delynoi/src/models/polygon/Polygon.cpp
@@ -81,8 +81,7 @@ double Polygon::calculateArea(std::vector<Point>& p) {
 
 double Polygon::getArea(std::vector<Point>& points){
     if(this->area == -1){
-        std::vector<Point> thisPoints = this->getPoints(points);
-        this->calculateArea(thisPoints);
+        this->area = this->calculateArea(points);
     }
 
     return this->area;
@@ -91,7 +90,7 @@ double Polygon::getArea(std::vector<Point>& points){
 double Polygon::getDiameter(std::vector<Point>& points) {
     if(this->diameter < 0){
         std::vector<Point> thisPoints = this->getPoints(points);
-        this->calculateDiameter(thisPoints);
+        this->diameter = this->calculateDiameter(thisPoints);
     }
 
     return this->diameter;
@@ -100,7 +99,7 @@ double Polygon::getDiameter(std::vector<Point>& points) {
 Point Polygon::getCentroid(std::vector<Point>& points) {
     if(!this->centroid.isValid()){
         std::vector<Point> thisPoints = this->getPoints(points);
-        this->calculateCentroid(thisPoints);
+        this->centroid = this->calculateCentroid(thisPoints);
     }
 
     return this->centroid;
@@ -272,7 +271,7 @@ void Polygon::calculateHash() {
 void Polygon::fixCCW(std::vector<Point> &p) {
     if(isClockwise(p)){
         std::reverse(this->points.begin(), this->points.end());
-        this->area = -this->area;
+        this->area = -1;
     }
 }
 

--- a/delynoi/src/utilities/delynoi_utilities.cpp
+++ b/delynoi/src/utilities/delynoi_utilities.cpp
@@ -35,7 +35,7 @@ namespace delynoi_utilities {
         int steps = DelynoiConfig::instance()->getDiscretizationGrade();
         double delta = (endAngle - initAngle)/steps;
 
-        for(int i=0; i<steps;i++){
+        for(int i=0; i<=steps;i++){
             double angle = initAngle + delta*i;
 
             double x = center.getX() + radius*std::cos(utilities::radian(angle));

--- a/lib/utilities/include/utilities/utilities.h
+++ b/lib/utilities/include/utilities/utilities.h
@@ -20,7 +20,7 @@ namespace utilities{
     }
 
     template <typename T>
-    int indexOf(std::vector<T> vector, T element){
+    int indexOf(const std::vector<T>& vector, T element){
         int pos = std::find(vector.begin(), vector.end(), element) - vector.begin();
 
         return pos < (int) vector.size()? pos : -1;


### PR DESCRIPTION
- Changed the `PRIVATE` property of the CMakeLists for *triangle* to `PUBLIC`. Otherwise the flags given are not propagated to the higher level projects (utilities, delynoi). The lack of this caused a linking error under Windows.
- Removed a line in the install. That line caused an error both with GCC and with Visual C++.